### PR TITLE
feat: add user-defined remote path

### DIFF
--- a/slurmpilot/job_creation_info.py
+++ b/slurmpilot/job_creation_info.py
@@ -17,7 +17,7 @@ class JobCreationInfo:
         None  # if specified a bash command that gets executed before the main script
     )
     src_dir: str | None = None
-    remote_dir: str | None = None
+    remote_dir: str | None = None  # directory to write slurmpilot file in remote cluster, default to what is configured in your cluster configuration
     exp_id: str | None = None
 
     sbatch_arguments: str | None = None  # argument to be passed to sbatch

--- a/slurmpilot/job_creation_info.py
+++ b/slurmpilot/job_creation_info.py
@@ -17,6 +17,7 @@ class JobCreationInfo:
         None  # if specified a bash command that gets executed before the main script
     )
     src_dir: str | None = None
+    remote_dir: str | None = None
     exp_id: str | None = None
 
     sbatch_arguments: str | None = None  # argument to be passed to sbatch

--- a/slurmpilot/slurm_wrapper.py
+++ b/slurmpilot/slurm_wrapper.py
@@ -103,10 +103,11 @@ class SlurmWrapper:
         """
         job_info.check_path()
         cluster_connection = self.connections[job_info.cluster]
-        home_dir = self.home_dir[job_info.cluster]
 
-        root_dir = job_info.remote_dir if job_info.remote_dir is not None else home_dir
-        root_path = os.path.join(root_dir, "slurmpilot")
+        if job_info.remote_dir is None:
+            root_path = self.config.remote_slurmpilot_path(job_info.cluster)
+        else:
+            root_path = job_info.remote_dir
 
         self.job_scheduling_callback.on_job_scheduled_start(
             cluster=job_info.cluster, jobname=job_info.jobname

--- a/slurmpilot/slurm_wrapper.py
+++ b/slurmpilot/slurm_wrapper.py
@@ -104,6 +104,10 @@ class SlurmWrapper:
         job_info.check_path()
         cluster_connection = self.connections[job_info.cluster]
         home_dir = self.home_dir[job_info.cluster]
+
+        root_dir = job_info.remote_dir if job_info.remote_dir is not None else home_dir
+        root_path = os.path.join(root_dir, "slurmpilot")
+
         self.job_scheduling_callback.on_job_scheduled_start(
             cluster=job_info.cluster, jobname=job_info.jobname
         )
@@ -113,7 +117,7 @@ class SlurmWrapper:
 
         # tar and send slurmpilot dir
         remote_job_paths = self.remote_path(
-            job_info, root_path=str(home_dir / "slurmpilot")
+            job_info, root_path=root_path
         )
         self.job_scheduling_callback.on_sending_artifact(
             localpath=str(local_job_paths.resolve_path()),


### PR DESCRIPTION
Thank you for the great library! :)

I was beginning to use it, and couldn't find a way to push the files to my workspace in SLURM -- it always copies the folder to `slurmpilot` in the home directory.  This PR lets the user specify the root directory in the cluster where it should copy the files to.