### PR TITLE
feat: load experiment config from yaml file

### DIFF
--- a/examples/hellocluster-yaml/config.yaml
+++ b/examples/hellocluster-yaml/config.yaml
@@ -1,0 +1,22 @@
+# The cluster to run on
+cluster: kislurm
+
+# Everything that goes into the SBATCH preamble goes here
+job:
+  partition: testdlc_gpu-rtx2080
+  n_cpus: 1
+  max_runtime_minutes: 60
+  jobname: my-experiment
+
+# Script related settings
+script:
+  entrypoint: hellocluster_script_template.sh
+  src_dir: ./
+  env:
+    API_TOKEN: DUMMY
+
+# The keywords and the values to replace them with if a template bash script is used as the entrypoint, ignored otherwise
+# Remember that every keyword in the bash script must be replaced with a (valid) value for the script to run properly.
+template:
+  $$UPPERBOUND$$: 15
+  $$GIT_COMMIT_OR_BRANCH$$: big-refactor

--- a/examples/hellocluster-yaml/hellocluster_script_template.sh
+++ b/examples/hellocluster-yaml/hellocluster_script_template.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+echo "Workingdir: $PWD";
+echo "Started at $(date)";
+echo "Running job $SLURM_JOB_NAME using $SLURM_JOB_CPUS_PER_NODE cpus per node with given JID $SLURM_JOB_ID on queue $SLURM_JOB_PARTITION";
+echo "Environment variables"
+env
+
+# An example of using templates
+for i in {1..$$UPPERBOUND$$};
+  do echo $RANDOM >> integers.txt;
+done
+echo "Finished at $(date)";
+
+# They templates could also be used for more advanced stuff. E.g. (taken from slurmpilot-freiburg)
+
+# git clone https://github.com/EleutherAI/lm-evaluation-harness
+# cd lm-evaluation-harness
+# pip install -e .
+# git checkout $$GIT_COMMIT_OR_BRANCH$$   # The commit or branch could be specified in the yaml file.
+# pip install evaluate  # required for big-refactor branch
+
+# # 2.7B model from microsoft, principally trained on coding but also artificial NLP tasks
+# # https://huggingface.co/microsoft/phi-2
+# model=microsoft/phi-2
+
+# # 7B models will OOMs on 2080/3080
+# # model=lvkaokao/mistral-7b-finetuned-orca-dpo-v2
+
+# # Evaluate only 10 examples per task
+# # Download model and datasets, ~6 min
+# time PYTHONPATH=/home/$USER/lm-evaluation-harness python -m lm_eval \
+#     --model hf \
+#     --model_args pretrained=$model,dtype="bfloat16" \
+#     --tasks mmlu \
+#     --device cuda:0 \
+#     --batch_size 1 \
+#     --num_fewshot=0 \
+#     --limit 10

--- a/examples/hellocluster-yaml/launch_hellocluster.py
+++ b/examples/hellocluster-yaml/launch_hellocluster.py
@@ -1,0 +1,70 @@
+import argparse
+import yaml
+import logging
+
+from slurmpilot.config import default_cluster_and_partition
+from slurmpilot.slurm_wrapper import SlurmWrapper, JobCreationInfo
+from slurmpilot.util import unify
+
+def load_config(config_path):
+    """
+    Load configuration from a YAML file.
+    :param config_path: Path to the YAML configuration file.
+    :return: Parsed configuration as a dictionary.
+    """
+    with open(config_path, 'r') as file:
+        config = yaml.safe_load(file)
+    return config
+
+def main():
+    parser = argparse.ArgumentParser(description="Load configurations from a YAML file.")
+    parser.add_argument("config", type=str, help="Path to the YAML configuration file")
+    args = parser.parse_args()
+
+    # Load the configuration
+    config = load_config(args.config)
+
+    # Logging configuration
+    logging.basicConfig(level=logging.INFO)
+
+    cluster = config.get("cluster", None)
+    if cluster is None:
+        cluster, partition = default_cluster_and_partition()
+        logging.warn(f"Cluster not specified. Using the default cluster ({cluster}) and partition ({partition}).")
+    else:
+        partition = config["job"].get("partition", None)
+        assert partition is not None, f"The cluster is specified ({cluster}), but the partition isn't. Either specify both or neither."
+
+    # set the job name
+    method = config.get("method", "coolname")
+    jobname = unify(config["job"].get("jobname", "default-job-name"), method)
+    max_runtime_minutes = config.get("max_runtime_minutes", 24 * 60)
+
+    slurm = SlurmWrapper(clusters=[cluster])
+
+    script_config = config.get("script", {})
+    job_config = config.get("job")
+    template_data = config.get("template", {})
+
+    for key in ["partition", "jobname"]:
+        job_config.pop(key, None)
+
+    # Job Information
+    jobinfo = JobCreationInfo(
+        cluster=cluster,
+        partition=partition,
+        jobname=jobname,
+        **job_config,
+        **script_config,
+        template_data=template_data
+    )
+
+    jobid = slurm.schedule_job(jobinfo)
+    slurm.wait_completion(jobname=jobname, max_seconds=max_runtime_minutes * 60)
+    print(slurm.job_creation_metadata(jobname))
+    print(slurm.status(jobname))
+    print("--logs:")
+    slurm.print_log(jobname=jobname)
+
+if __name__ == "__main__":
+    main()

--- a/slurmpilot/job_creation_info.py
+++ b/slurmpilot/job_creation_info.py
@@ -43,6 +43,10 @@ class JobCreationInfo:
     env: dict = None
     nodes: int = None  # number of nodes for this job
     nodelist: str = None
+    entrypoint_template: str | None = None
+    # Used when the bash file provided is a "template", i.e., it has keywords which should should be replaced.
+    # It is inferred in post and does not have to specified by the user.
+    template_data: dict | None = None  # dictionary with the keywords and the strings to replace them with in the template file
     
     def __post_init__(self):
         if self.python_args:
@@ -57,14 +61,26 @@ class JobCreationInfo:
         if self.src_dir is None:
             self.src_dir = "./"
 
+        # TODO: A bit hacky, this. But I think that naming the bash file with an explicit "_template.sh"
+        # is the safest way to ensure that the user doesn't accidentally use a non template as a template
+        # or vice-a-versa.
+        if self.entrypoint.endswith("_template.sh"):
+            self.entrypoint_template = self.entrypoint
+            self.entrypoint = self.entrypoint[:-len("_template.sh")]
+        else:
+            self.entrypoint_template = None
+
     def check_path(self):
         assert Path(
             self.src_dir
         ).exists(), f"The src_dir path {self.src_dir} is missing."
-        entrypoint_path = Path(self.src_dir) / self.entrypoint
-        assert (
+
+        file_name = self.entrypoint if self.entrypoint_template is None else self.entrypoint_template
+        entrypoint_path = Path(self.src_dir) / file_name
+
+        assert(
             entrypoint_path.exists()
-        ), f"The entrypoint could not be found at {entrypoint_path}."
+        ), f"The entrypoint template could not be found at {entrypoint_path}."
 
     def sbatch_preamble(self) -> str:
         """


### PR DESCRIPTION
This PR introduces a way to store all the configuration related to an experiment in a YAML file.

To give the user the flexibility to fully describe the parameters of an experiment in the YAML, I've introduced the notion of _template entrypoint scripts_. These are bash scripts that the user writes, but with placeholders for some parameters. If the entrypoint script ends in `_template.sh`, slurmpilot will generate the final script by replacing every keyword that appears in the template with its desired value. The keywords and their values are defined in the `template` section of the YAML file. So an experiment can be fully described by a combination of a `config.yaml` and a `cluster_script.sh` or `cluster_script_template.sh`.

You can test this by running `python launch_hellocluster.py config.yaml`

Ideally, the script `launch_hellocluster.py` should be a standalone command like `slurmpilot --run config.yaml` so that we can launch experiments from the command line.