### PR TITLE
add ssh subproces backend, remove fabrik

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,4 +21,3 @@ packages = [
 python = ">= 3.10.0"
 pyyaml = ">= 5.0"
 pandas = ">= 2.0"
-paramiko = ">= 3.0"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ setup(
     install_requires=[
         "pyyaml",
         "pandas",
-        "fabric",
     ],
     extras_require={
         "dev": ["pytest", "black", "pre-commit"],

--- a/slurmpilot/job_metadata.py
+++ b/slurmpilot/job_metadata.py
@@ -78,6 +78,6 @@ def list_metadatas(root: Path, n_jobs: int | None = None) -> list[JobMetadata]:
         with open(file, "r") as f:
             try:
                 jobs.append(JobMetadata.from_json(f.read()))
-            except json.decoder.JSONDecodeError:
+            except (json.decoder.JSONDecodeError, TypeError) as _:
                 pass
     return jobs

--- a/slurmpilot/remote_command.py
+++ b/slurmpilot/remote_command.py
@@ -3,6 +3,7 @@ import socket
 import subprocess
 import tempfile
 import time
+import traceback
 from dataclasses import dataclass
 from getpass import getpass
 from pathlib import Path
@@ -10,6 +11,7 @@ import tarfile
 
 import paramiko
 
+from slurmpilot.callback import format_highlight
 from slurmpilot.util import path_size_human_readable
 
 logger = logging.getLogger(__name__)
@@ -93,6 +95,119 @@ class LocalCommandExecution(RemoteExecution):
     def download_folder(self, remote_path: Path, local_path: Path):
         # TODO copy file locally
         raise NotImplementedError()
+
+
+class RemoteCommandExecutionSubprocess(RemoteExecution):
+    def __init__(
+        self,
+        master: str,
+        user: str | None = None,
+        proxy: str | None = None,
+        local_dir: str | Path = None,
+    ):
+        """
+        :param master:
+        :param user:
+        :param proxy:
+        :param local_dir: where logs are written, if None, use tempdir
+        """
+        super().__init__(master=master, proxy=proxy, user=user)
+        self.local_dir = local_dir if local_dir else tempfile.mkdtemp()
+        self.local_dir = Path(self.local_dir)
+
+    def run(
+        self, command: str, pty: bool = False, env: dict | None = None, retries: int = 0
+    ) -> CommandResult:
+        command = f"ssh {self._remote_ssh_hostname()} {command}"
+        return self._run_shell_command(
+            command=command, pty=pty, env=env, retries=retries
+        )
+
+    def _run_shell_command(
+        self, command: str, pty: bool = False, env: dict | None = None, retries: int = 0
+    ) -> CommandResult:
+        # TODO specify dir
+        with open(self.local_dir / "std.out", "w") as stdout:
+            with open(self.local_dir / "std.err", "w") as stderr:
+                process = subprocess.Popen(
+                    command.split(" "), stderr=stderr, stdout=stdout
+                )
+
+        # wait for ssh to be finished, return code is 100 in case of timeout
+        code = 100
+        for _ in range(20):
+            code = process.poll()
+            if code is not None:
+                break
+            time.sleep(1)
+
+        with open(self.local_dir / "std.out", "r") as f:
+            stdout = f.read()
+        with open(self.local_dir / "std.err", "r") as f:
+            stderr = f.read()
+
+        return CommandResult(
+            command=command,
+            failed=code != 0,
+            stderr=stderr,
+            stdout=stdout,
+            return_code=code,
+        )
+
+    def _remote_ssh_hostname(self) -> str:
+        # returns a string like salinasd@hostname
+        user_str = "" if self.user is None else self.user + "@"
+        return f"{user_str}{self.master}"
+
+    def upload_file(self, local_path: Path, remote_path: Path = Path("/")):
+        res = self._run_shell_command(
+            command=f"scp {local_path} {self._remote_ssh_hostname()}:{remote_path}",
+        )
+        if res.failed:
+            raise ValueError(
+                f"Failed to upload {local_path} to {self.master}: {res.stderr}"
+            )
+
+    def upload_folder(self, local_path: Path, remote_path: Path = Path("/")):
+        logger.info(
+            f"Running rsync from {format_highlight(str(local_path))} to {format_highlight(str(remote_path))}"
+        )
+        user_prefix = f"{self.user}@" if self.user else ""
+        command = f"rsync -aPvz {local_path} {user_prefix}{self.master}:{remote_path}"
+        res = self._run_shell_command(command=command)
+        if res.failed:
+            raise ValueError(
+                f"Failed to upload {local_path} to {self.master}: {res.stderr}"
+            )
+
+    def download_file(self, remote_path: Path, local_path: Path):
+        user_prefix = f"{self.user}@" if self.user else ""
+        command = f"scp {user_prefix}{self.master}:{remote_path} {local_path}"
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        res = self._run_shell_command(
+            command=command,
+        )
+        if res.failed:
+            raise ValueError(
+                f"Failed to download {remote_path} from {self.master} to {local_path}. \nCommand ran: {command}"
+            )
+
+    def download_folder(self, remote_path: Path, local_path: Path):
+        """
+        :param remote_path:
+        :param local_path:
+        :return:
+        """
+        # Note, we could also tar the whole thing like we do to send, the reason we pick rsync is that often
+        # some files will only be present and rsync allows to not copy those based on hashes
+        logger.info(
+            f"Running rsync from {format_highlight(remote_path)} to {format_highlight(local_path)}"
+        )
+        user_prefix = f"{self.user}@" if self.user else ""
+        command = (
+            f"rsync -aPvz {user_prefix}{self.master}:{remote_path} {local_path.parent}"
+        )
+        self._run_shell_command(command=command)
 
 
 class RemoteCommandExecutionFabrik(RemoteExecution):
@@ -238,19 +353,11 @@ class RemoteCommandExecutionFabrik(RemoteExecution):
         """
         # Note, we could also tar the whole thing like we do to send, the reason we pick rsync is that often
         # some files will only be present and rsync allows to not copy those based on hashes
-        logger.info(f"Running rsync from {remote_path} to {local_path}")
+        logger.info(
+            f"Running rsync from {format_highlight(remote_path)} to {format_highlight(local_path)}"
+        )
+        user_prefix = f"{self.user}@" if self.user else ""
         command = (
-            f"rsync -aPvz {self.user}@{self.master}:{remote_path} {local_path.parent}"
+            f"rsync -aPvz {user_prefix}{self.master}:{remote_path} {local_path.parent}"
         )
         subprocess.run(command.split(" "), check=True)
-
-
-if __name__ == "__main__":
-    connection = RemoteCommandExecutionFabrik(
-        master="YOURCLUSTER",
-        user="YOURUSER",
-        prompt_for_login_password=True,
-        prompt_for_passphrase=False,
-    )
-
-    print(connection.run("ls"))


### PR DESCRIPTION
Replace the previous ssh wrapper with native calls to scp and ssh to copy and run commands remotely. 

This allows to remove the dependency to paramiko/fabric which happens to fail sometimes in my case and is harder to debug than native ssh.