### PR TITLE
remove remote_path from general config

### DIFF
--- a/slurmpilot/config.py
+++ b/slurmpilot/config.py
@@ -20,9 +20,6 @@ class GeneralConfig(NamedTuple):
     # default path where slurmpilot job files are generated
     local_path: str = str(Path("~/slurmpilot").expanduser())
 
-    # default path where slurmpilot job files are generated on the remote machine, Note: "~" cannot be used
-    remote_path: str = str("slurmpilot/")
-
     # default cluster to be used, must have a file `config/clusters/{default_cluster}.yaml` associated
     default_cluster: str | None = None
 
@@ -40,7 +37,7 @@ class ClusterConfig:
 class Config:
     def __init__(
         self,
-        general_config: GeneralConfig | None = None,
+        general_config: GeneralConfig,
         cluster_configs: Dict[str, ClusterConfig] | None = None,
     ):
         self.general_config = general_config
@@ -88,7 +85,7 @@ class Config:
         if cluster in self.cluster_configs:
             return Path(self.cluster_configs[cluster].remote_path)
         else:
-            return Path(self.general_config.remote_path)
+            return Path(ClusterConfig.remote_path)
 
 
 def load_yaml(path: Path) -> dict:

--- a/tst/test_config.py
+++ b/tst/test_config.py
@@ -7,7 +7,7 @@ from slurmpilot.config import Config, load_config, GeneralConfig, ClusterConfig
 def test_save_config():
     path = Path("/tmp/foo")
     config = Config(
-        general_config=GeneralConfig(local_path="/a", remote_path="/b"),
+        general_config=GeneralConfig(local_path="/a"),
         cluster_configs={"cluster1": ClusterConfig(host="foo.org", remote_path="~/foo")}
     )
     config.save_to_path(path)

--- a/tst/test_slurm_wrapper.py
+++ b/tst/test_slurm_wrapper.py
@@ -22,7 +22,7 @@ def test_schedule_job():
         generate_local_script(src_dir=Path(src_dir), entrypoint=entrypoint)
         config = Config(
             general_config=GeneralConfig(
-                local_path=local_slurmpilot_path, remote_path=local_slurmpilot_path
+                local_path=local_slurmpilot_path
             ),
         )
         slurm = SlurmWrapper(


### PR DESCRIPTION
This PR removes `remote_path` from the general configuration, as it is specific to each cluster.