### PR TITLE
Fix: Use correct cluster config key check to resolve SSH hostname in SlurmPilot

### DIFF
--- a/slurmpilot/slurmpilot.py
+++ b/slurmpilot/slurmpilot.py
@@ -69,7 +69,7 @@ class SlurmPilot:
         self.connections = {}
 
         for cluster in clusters:
-            if cluster in self.config.cluster_configs.items():
+            if cluster in self.config.cluster_configs:
                 config = self.config.cluster_configs[cluster]
                 connection_kwargs = dict(
                     master=config.host,


### PR DESCRIPTION
# Summary

This PR fixes a bug in the SlurmPilot cluster connection logic that caused the SSH connection to use the cluster name (e.g., horeka) as the hostname, instead of the actual host field from the cluster config (e.g., horeka.scc.kit.edu ).

## Error description

While using Slurmpilot with a general.yaml and a per-cluster config (e.g., slurm_config/clusters/KI-cluster.yaml), I consistently received the error:
```bash
ssh: Could not resolve hostname ki-cluster: No address associated with hostname
```

This happened even though the host field was correctly set in my cluster config. Debugging revealed that Slurmpilot was ignoring the host field and using the cluster name as the SSH hostname.

## Root cause

In `slurmpilot.py`, the code checked:
```python
if cluster in self.config.cluster_configs.items():
```
But `self.config.cluster_configs.items()` is a set of `(key, value)` tuples, not just keys. This check always fails, so the code always falls back to using the cluster name as the SSH host.

## Impact

The fix correctly checks if the cluster name is a key in the cluster configs dictionary, allowing Slurmpilot to use the host field from the config as intended, allowing jobs to be submitted to the correct remote host.