### PR TITLE
support .gitignore to exclude files from upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,21 @@ sp launch --config example/python_dependencies/job.yaml --cluster local --partit
 python example/python_dependencies/launch_python_dependencies.py
 ```
 
+### Excluding files from the upload
+
+Slurmpilot reads the `.gitignore` at the root of your `src_dir` (and each `python_libraries` directory) and skips matching files when staging the copy that ships to the cluster. Standard `.gitignore` syntax applies:
+
+```
+# .gitignore
+*.log
+__pycache__/
+data/
+checkpoints/
+!keep-this.log
+```
+
+Sub-directory `.gitignore` files are not consulted.
+
 ## ⌨️ Command-Line Interface (CLI)
 
 All job commands accept an optional job name. When omitted, the most recently submitted job is used — so after `sp launch`, you can just run `sp log`, `sp status`, etc. without typing the job name:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ requires-python = ">=3.12"
 dependencies = [
     "pyyaml>=6.0.3",
     "coolname>=2.0",
+    "pathspec>=0.12",
 ]
 
 [project.urls]

--- a/slurmpilot/ignore.py
+++ b/slurmpilot/ignore.py
@@ -35,6 +35,9 @@ def make_ignore(root: Path):
         for name in names:
             rel_path = (rel_dir / name).as_posix()
             is_dir = (src_path / name).is_dir()
+            if name.startswith("."):
+                ignored.add(name)
+                continue
             # gitwildmatch requires a trailing slash to match directory-only patterns.
             if spec.match_file(rel_path) or (
                 is_dir and spec.match_file(rel_path + "/")

--- a/slurmpilot/ignore.py
+++ b/slurmpilot/ignore.py
@@ -1,0 +1,45 @@
+"""Gitignore-style filtering for files copied into the staging job folder.
+
+Patterns are read from a ``.gitignore`` file at the root of each source
+directory (``src_dir`` and each ``python_libraries`` entry). Sub-directory
+``.gitignore`` files are not consulted.
+"""
+
+from pathlib import Path
+
+import pathspec
+
+IGNORE_FILENAME = ".gitignore"
+
+
+def _load_gitignore(directory: Path) -> list[str]:
+    path = directory / IGNORE_FILENAME
+    if not path.exists():
+        return []
+    return path.read_text().splitlines()
+
+
+def make_ignore(root: Path):
+    """Return a ``shutil.copytree``-compatible ignore callable.
+
+    Patterns are read from ``root/.gitignore``.
+    """
+    patterns = _load_gitignore(root)
+
+    spec = pathspec.PathSpec.from_lines("gitwildmatch", patterns)
+
+    def ignore(src: str, names: list[str]) -> set[str]:
+        src_path = Path(src)
+        rel_dir = src_path.relative_to(root)
+        ignored: set[str] = set()
+        for name in names:
+            rel_path = (rel_dir / name).as_posix()
+            is_dir = (src_path / name).is_dir()
+            # gitwildmatch requires a trailing slash to match directory-only patterns.
+            if spec.match_file(rel_path) or (
+                is_dir and spec.match_file(rel_path + "/")
+            ):
+                ignored.add(name)
+        return ignored
+
+    return ignore

--- a/slurmpilot/slurm_script.py
+++ b/slurmpilot/slurm_script.py
@@ -51,8 +51,8 @@ def _write_preamble(f: io.StringIO, job_info: JobCreationInfo) -> None:
         sbatch(f"--account={job_info.account}")
     if job_info.max_runtime_minutes:
         sbatch(f"--time={job_info.max_runtime_minutes}")
-    if job_info.sbatch_arguments:
-        f.write(f"#SBATCH {job_info.sbatch_arguments}\n")
+    for argument in job_info.sbatch_arguments:
+        f.write(f"#SBATCH {argument}\n")
 
 
 def _write_body(

--- a/slurmpilot/slurmpilot.py
+++ b/slurmpilot/slurmpilot.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import List
 
 from .config import Config, default_cluster_and_partition, load_config  # noqa: F401
+from .ignore import make_ignore
 from .job_creation_info import JobCreationInfo  # noqa: F401
 from .job_metadata import JobMetadata
 from .job_path import JobPath
@@ -27,7 +28,9 @@ LOCAL_CLUSTER = "local"
 # sacct format used throughout — must match MockSlurm.SACCT_HEADER
 SACCT_FORMAT = "JobID,Elapsed,start,State,nodelist"
 
-TERMINAL_STATES = frozenset({"COMPLETED", "FAILED", "CANCELLED", "TIMEOUT", "OUT_OF_MEMORY"})
+TERMINAL_STATES = frozenset(
+    {"COMPLETED", "FAILED", "CANCELLED", "TIMEOUT", "OUT_OF_MEMORY"}
+)
 
 
 @dataclass
@@ -69,17 +72,21 @@ def _parse_squeue_rows(output: str) -> list[dict]:
         if len(parts) < 3:
             continue
         try:
-            rows.append({
-                "jobid": int(parts[0].strip()),
-                "priority": int(parts[1].strip()),
-                "state": parts[2].strip(),
-            })
+            rows.append(
+                {
+                    "jobid": int(parts[0].strip()),
+                    "priority": int(parts[1].strip()),
+                    "state": parts[2].strip(),
+                }
+            )
         except ValueError:
             continue
     return rows
 
 
-def _compute_queue_position(jobid: int, partition: str, rows: list[dict]) -> QueuePosition:
+def _compute_queue_position(
+    jobid: int, partition: str, rows: list[dict]
+) -> QueuePosition:
     """Derive a :class:`QueuePosition` from parsed squeue rows.
 
     *rows* must already be sorted by priority descending (as returned by
@@ -142,11 +149,15 @@ class SlurmPilot:
             else:
                 cfg = self.config.cluster_configs.get(cluster)
                 if cfg:
-                    self._connections[cluster] = SSHExecution(host=cfg.host, user=cfg.user)
+                    self._connections[cluster] = SSHExecution(
+                        host=cfg.host, user=cfg.user
+                    )
                 else:
                     self._connections[cluster] = SSHExecution(host=cluster)
 
-    def schedule_job(self, job_info: JobCreationInfo, dryrun: bool = False) -> int | None:
+    def schedule_job(
+        self, job_info: JobCreationInfo, dryrun: bool = False
+    ) -> int | None:
         """Prepare and submit a job.
 
         Copies ``src_dir`` to the local job folder, generates ``slurm_script.sh``,
@@ -172,7 +183,12 @@ class SlurmPilot:
                 "Jobnames must be unique. Use unify(jobname) to append a unique suffix automatically."
             )
 
-        shutil.copytree(src=job_info.src_dir, dst=local.src)
+        src_path = Path(job_info.src_dir)
+        shutil.copytree(
+            src=src_path,
+            dst=local.src,
+            ignore=make_ignore(src_path),
+        )
         if isinstance(job_info.python_args, list):
             lines = []
             for arg in job_info.python_args:
@@ -184,7 +200,11 @@ class SlurmPilot:
         if job_info.python_libraries:
             for lib in job_info.python_libraries:
                 lib_path = Path(lib)
-                shutil.copytree(src=lib_path, dst=local.job_dir / lib_path.name)
+                shutil.copytree(
+                    src=lib_path,
+                    dst=local.job_dir / lib_path.name,
+                    ignore=make_ignore(lib_path),
+                )
 
         job_run_dir = self._job_run_dir(job_info.cluster, local, job_info)
         script = generate_slurm_script(
@@ -234,8 +254,12 @@ class SlurmPilot:
         if cluster is not None and cluster not in (MOCK_CLUSTER, LOCAL_CLUSTER):
             self._download_logs(cluster, jobname, local)
 
-        stdout = local.stdout.read_text(errors="replace") if local.stdout.exists() else ""
-        stderr = local.stderr.read_text(errors="replace") if local.stderr.exists() else ""
+        stdout = (
+            local.stdout.read_text(errors="replace") if local.stdout.exists() else ""
+        )
+        stderr = (
+            local.stderr.read_text(errors="replace") if local.stderr.exists() else ""
+        )
         return stdout, stderr
 
     # ------------------------------------------------------------------
@@ -248,11 +272,17 @@ class SlurmPilot:
             return Path(job_info.remote_path)
         return self.config.remote_slurmpilot_path(job_info.cluster)
 
-    def _job_run_dir(self, cluster: str, local: JobPath, job_info: JobCreationInfo | None = None) -> Path:
+    def _job_run_dir(
+        self, cluster: str, local: JobPath, job_info: JobCreationInfo | None = None
+    ) -> Path:
         """Working directory on the execution host embedded in the Slurm script."""
         if cluster in (MOCK_CLUSTER, LOCAL_CLUSTER):
             return local.job_dir
-        root = self._remote_root(job_info) if job_info else self.config.remote_slurmpilot_path(cluster)
+        root = (
+            self._remote_root(job_info)
+            if job_info
+            else self.config.remote_slurmpilot_path(cluster)
+        )
         return JobPath(
             jobname=local.jobname,
             root=root,
@@ -306,12 +336,16 @@ class SlurmPilot:
             root=self._remote_root_for_job(jobname, cluster),
         )
         try:
-            self._connections[cluster].download_folder(remote.log_dir, local.log_dir.parent)
+            self._connections[cluster].download_folder(
+                remote.log_dir, local.log_dir.parent
+            )
         except Exception as e:
             logger.warning(f"Could not download logs for {jobname}: {e}")
 
     def _read_jobid(self, jobname: str) -> int | None:
-        f = JobPath(jobname=jobname, root=self.config.local_slurmpilot_path()).jobid_file
+        f = JobPath(
+            jobname=jobname, root=self.config.local_slurmpilot_path()
+        ).jobid_file
         if not f.exists():
             return None
         return json.loads(f.read_text())["jobid"]
@@ -340,6 +374,7 @@ class SlurmPilot:
         ``creation``, ``elapsed``, ``state``, ``nodelist``.
         """
         from collections import defaultdict
+
         by_cluster: dict[str, list[tuple[JobMetadata, int]]] = defaultdict(list)
         for jn in jobnames:
             meta = self._read_metadata(jn)
@@ -358,7 +393,9 @@ class SlurmPilot:
                     f'sacct --format="{SACCT_FORMAT}" -X -p --jobs={job_ids_str}'
                 )
                 if result.failed:
-                    logger.warning(f"sacct failed for cluster {cluster}: {result.stderr}")
+                    logger.warning(
+                        f"sacct failed for cluster {cluster}: {result.stderr}"
+                    )
                     continue
                 sacct_out = result.stdout
 
@@ -378,16 +415,18 @@ class SlurmPilot:
                     parsed_task_id = int(task_id) if task_id is not None else None
                 except ValueError:
                     parsed_task_id = None
-                rows.append({
-                    "jobname":  meta.jobname,
-                    "jobid":    raw_id,
-                    "task_id":  parsed_task_id,
-                    "cluster":  cluster,
-                    "creation": meta.date,
-                    "elapsed":  parts[1] if len(parts) > 1 else "",
-                    "state":    parts[3] if len(parts) > 3 else None,
-                    "nodelist": parts[4] if len(parts) > 4 else "",
-                })
+                rows.append(
+                    {
+                        "jobname": meta.jobname,
+                        "jobid": raw_id,
+                        "task_id": parsed_task_id,
+                        "cluster": cluster,
+                        "creation": meta.date,
+                        "elapsed": parts[1] if len(parts) > 1 else "",
+                        "state": parts[3] if len(parts) > 3 else None,
+                        "nodelist": parts[4] if len(parts) > 4 else "",
+                    }
+                )
         return rows
 
     def stop_job(self, jobname: str) -> None:
@@ -459,12 +498,16 @@ class SlurmPilot:
         if cluster in (MOCK_CLUSTER, LOCAL_CLUSTER):
             return
         local = JobPath(jobname=jobname, root=self.config.local_slurmpilot_path())
-        remote = JobPath(jobname=jobname, root=self._remote_root_for_job(jobname, cluster))
+        remote = JobPath(
+            jobname=jobname, root=self._remote_root_for_job(jobname, cluster)
+        )
         self._connections[cluster].download_folder(remote.job_dir, local.job_dir.parent)
 
     def local_job_path(self, jobname: str) -> Path:
         """Return the local job directory for ``jobname``."""
-        return JobPath(jobname=jobname, root=self.config.local_slurmpilot_path()).job_dir
+        return JobPath(
+            jobname=jobname, root=self.config.local_slurmpilot_path()
+        ).job_dir
 
     def remote_job_path(self, jobname: str) -> Path | None:
         """Return the remote job directory, or None for mock/local clusters."""
@@ -532,6 +575,7 @@ class SlurmPilot:
 # ------------------------------------------------------------------
 # Module-level helpers for real Slurm CLI calls
 # ------------------------------------------------------------------
+
 
 def _call_sbatch(
     connection: RemoteExecution,

--- a/tst/test_cli.py
+++ b/tst/test_cli.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
 from slurmpilot.cli import (
     _resolve_jobname,
     cmd_list_jobs,
@@ -272,7 +271,7 @@ def test_cmd_list_jobs_no_jobs(config, capsys):
 
 def test_launch_yaml_python_libraries_resolved_relative_to_yaml(tmp_path):
     """python_libraries relative paths in YAML are resolved against the YAML file's directory."""
-    from slurmpilot.cli import _build_job_info, _LAUNCH_FIELDS
+    from slurmpilot.cli import _LAUNCH_FIELDS, _build_job_info
 
     src = tmp_path / "src"
     src.mkdir()
@@ -284,13 +283,13 @@ def test_launch_yaml_python_libraries_resolved_relative_to_yaml(tmp_path):
 
     yaml_file = tmp_path / "job.yaml"
     yaml_file.write_text(
-        f"cluster: mock\n"
-        f"entrypoint: run.py\n"
-        f"jobname: test-job\n"
-        f"src_dir: src\n"
-        f"python_binary: python3\n"
-        f"python_libraries:\n"
-        f"  - mylib\n"
+        "cluster: mock\n"
+        "entrypoint: run.py\n"
+        "jobname: test-job\n"
+        "src_dir: src\n"
+        "python_binary: python3\n"
+        "python_libraries:\n"
+        "  - mylib\n"
     )
 
     args = argparse.Namespace(
@@ -385,7 +384,7 @@ def test_cmd_queue_status_mock_cluster(job, config, capsys):
 
 def test_launch_cli_remote_path_overrides_yaml(tmp_path):
     """--remote-path CLI flag overrides the value from YAML."""
-    from slurmpilot.cli import _build_job_info, _LAUNCH_FIELDS
+    from slurmpilot.cli import _LAUNCH_FIELDS, _build_job_info
 
     src = tmp_path / "src"
     src.mkdir()
@@ -413,7 +412,7 @@ def test_launch_cli_remote_path_overrides_yaml(tmp_path):
 
 def test_launch_cli_python_libraries_overrides_yaml(tmp_path):
     """--python-libraries CLI flag overrides the value from YAML."""
-    from slurmpilot.cli import _build_job_info, _LAUNCH_FIELDS
+    from slurmpilot.cli import _LAUNCH_FIELDS, _build_job_info
 
     src = tmp_path / "src"
     src.mkdir()
@@ -447,7 +446,7 @@ def test_launch_cli_python_libraries_overrides_yaml(tmp_path):
 
 def test_launch_cli_python_libraries_no_yaml(tmp_path):
     """--python-libraries works without a YAML config, resolved against cwd."""
-    from slurmpilot.cli import _build_job_info, _LAUNCH_FIELDS
+    from slurmpilot.cli import _LAUNCH_FIELDS, _build_job_info
 
     src = tmp_path / "src"
     src.mkdir()

--- a/tst/test_config.py
+++ b/tst/test_config.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import pytest
 import yaml
-
 from slurmpilot.config import ClusterConfig, Config, default_cluster_and_partition, load_config
 
 

--- a/tst/test_mock_slurm.py
+++ b/tst/test_mock_slurm.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import pytest
-
 from slurmpilot.mock_slurm import MockSlurm
 
 # ---------------------------------------------------------------------------

--- a/tst/test_remote_command.py
+++ b/tst/test_remote_command.py
@@ -3,7 +3,6 @@ from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from slurmpilot.remote_command import CommandResult, LocalExecution, SSHExecution
 
 # ---------------------------------------------------------------------------

--- a/tst/test_slurmpilot.py
+++ b/tst/test_slurmpilot.py
@@ -3,9 +3,9 @@ import sys
 from pathlib import Path
 
 import pytest
-
 from slurmpilot.config import Config
 from slurmpilot.job_creation_info import JobCreationInfo
+
 from slurmpilot import SlurmPilot
 
 # ---------------------------------------------------------------------------
@@ -532,3 +532,111 @@ class TestRemotePath:
         script = (tmp_path / "jobs" / "myjob" / "slurm_script.sh").read_text()
         assert "PYTHONPATH" in script
         assert "/custom/root" in script
+
+
+# ---------------------------------------------------------------------------
+# .gitignore — patterns that exclude files/folders from the staged copy
+# ---------------------------------------------------------------------------
+
+def make_src_with_filtered_files(tmp_path: Path) -> Path:
+    """A src dir with assorted files used to verify .gitignore filtering."""
+    src = make_bash_src(tmp_path / "src")
+    (src / "keep.txt").write_text("keep\n")
+    (src / "skip.log").write_text("skip\n")
+    (src / "data").mkdir()
+    (src / "data" / "big.bin").write_text("x")
+    (src / "__pycache__").mkdir()
+    (src / "__pycache__" / "x.pyc").write_text("")
+    return src
+
+
+def staged_src(tmp_path: Path, jobname: str = "myjob") -> Path:
+    return tmp_path / "jobs" / jobname / "src"
+
+
+class TestGitignore:
+    def test_gitignore_excludes_matching_files(self, tmp_path):
+        src = make_src_with_filtered_files(tmp_path)
+        (src / ".gitignore").write_text("*.log\ndata/\n__pycache__/\n")
+        slurm = SlurmPilot(config=make_config(tmp_path), clusters=["mock"])
+        job = JobCreationInfo(
+            jobname="myjob",
+            entrypoint="main.sh",
+            src_dir=str(src),
+            cluster="mock",
+        )
+        slurm.schedule_job(job, dryrun=True)
+        staged = staged_src(tmp_path)
+        assert (staged / "main.sh").exists()
+        assert (staged / "keep.txt").exists()
+        assert not (staged / "skip.log").exists()
+        assert not (staged / "data").exists()
+        assert not (staged / "__pycache__").exists()
+
+    def test_negation_re_includes_file(self, tmp_path):
+        src = make_src_with_filtered_files(tmp_path)
+        (src / "keep.log").write_text("keep me\n")
+        (src / ".gitignore").write_text("*.log\n!keep.log\n")
+        slurm = SlurmPilot(config=make_config(tmp_path), clusters=["mock"])
+        job = JobCreationInfo(
+            jobname="myjob",
+            entrypoint="main.sh",
+            src_dir=str(src),
+            cluster="mock",
+        )
+        slurm.schedule_job(job, dryrun=True)
+        staged = staged_src(tmp_path)
+        assert (staged / "keep.log").exists()
+        assert not (staged / "skip.log").exists()
+
+    def test_no_gitignore_no_filtering(self, tmp_path):
+        src = make_src_with_filtered_files(tmp_path)
+        slurm = SlurmPilot(config=make_config(tmp_path), clusters=["mock"])
+        job = JobCreationInfo(
+            jobname="myjob",
+            entrypoint="main.sh",
+            src_dir=str(src),
+            cluster="mock",
+        )
+        slurm.schedule_job(job, dryrun=True)
+        staged = staged_src(tmp_path)
+        assert (staged / "skip.log").exists()
+        assert (staged / "data" / "big.bin").exists()
+
+    def test_nested_pattern_matches_subdir_file(self, tmp_path):
+        src = make_bash_src(tmp_path / "src")
+        (src / "pkg").mkdir()
+        (src / "pkg" / "keep.py").write_text("")
+        (src / "pkg" / "drop.pyc").write_text("")
+        (src / ".gitignore").write_text("*.pyc\n")
+        slurm = SlurmPilot(config=make_config(tmp_path), clusters=["mock"])
+        job = JobCreationInfo(
+            jobname="myjob",
+            entrypoint="main.sh",
+            src_dir=str(src),
+            cluster="mock",
+        )
+        slurm.schedule_job(job, dryrun=True)
+        staged = staged_src(tmp_path)
+        assert (staged / "pkg" / "keep.py").exists()
+        assert not (staged / "pkg" / "drop.pyc").exists()
+
+    def test_python_library_gitignore_applied(self, tmp_path):
+        lib_dir = make_custom_lib(tmp_path / "libs")
+        (lib_dir / "tests").mkdir()
+        (lib_dir / "tests" / "test_x.py").write_text("")
+        (lib_dir / ".gitignore").write_text("tests/\n")
+        src = make_python_src_using_lib(tmp_path / "src")
+        slurm = SlurmPilot(config=make_config(tmp_path), clusters=["mock"])
+        job = JobCreationInfo(
+            jobname="libjob",
+            entrypoint="main.py",
+            src_dir=str(src),
+            cluster="mock",
+            python_binary=sys.executable,
+            python_libraries=[str(lib_dir)],
+        )
+        slurm.schedule_job(job, dryrun=True)
+        staged_lib = tmp_path / "jobs" / "libjob" / "mylib"
+        assert (staged_lib / "values.py").exists()
+        assert not (staged_lib / "tests").exists()

--- a/tst/test_slurmpilot_clusters.py
+++ b/tst/test_slurmpilot_clusters.py
@@ -10,10 +10,10 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from slurmpilot.config import ClusterConfig, Config
 from slurmpilot.job_creation_info import JobCreationInfo
 from slurmpilot.remote_command import CommandResult, RemoteExecution
+
 from slurmpilot import SlurmPilot
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adresses issue #32 to implement a feature to ignore all files and folders listed in the `.gitignore`. I introduced an additional dependency in `pathspec` to parse the `.gitignore` properly. Files are ignored by passing an `ignore` fn to `shutil.treecopy`.  I also ran `pytest` and `ruff check slurmpilot tst` leading to formatting of some files I didn't even modify. 